### PR TITLE
Review/unit test refactor

### DIFF
--- a/lib/Evaluator.cpp
+++ b/lib/Evaluator.cpp
@@ -69,8 +69,8 @@ void Evaluator::setupExpressionMap()
 QVariant Evaluator::get(const QJsonArray & array, const AbstractLayerFeature * feature, int mapZoomLevel, float vpZoomeLevel)
 {
     QString property = array.at(1).toString();
-    if(feature->fetureMetaData.contains(property)){
-        return feature->fetureMetaData[property];
+    if(feature->featureMetaData.contains(property)){
+        return feature->featureMetaData[property];
     }else{
         return {};
     }
@@ -89,7 +89,7 @@ QVariant Evaluator::get(const QJsonArray & array, const AbstractLayerFeature * f
 QVariant Evaluator::has(const QJsonArray &array, const AbstractLayerFeature *feature, int mapZoomLevel, float vpZoomeLevel)
 {
     QString property = array.at(1).toString();
-    return feature->fetureMetaData.contains(property);
+    return feature->featureMetaData.contains(property);
 }
 
 
@@ -106,8 +106,8 @@ QVariant Evaluator::has(const QJsonArray &array, const AbstractLayerFeature *fea
 QVariant Evaluator::in(const QJsonArray &array, const AbstractLayerFeature *feature, int mapZoomLevel, float vpZoomeLevel)
 {
     QString keyword = array.at(1).toString();
-    if(feature->fetureMetaData.contains(keyword)){
-        QVariant value = feature->fetureMetaData[keyword];
+    if(feature->featureMetaData.contains(keyword)){
+        QVariant value = feature->featureMetaData[keyword];
 
         auto temp = array.toVariantList().sliced(2).contains(value);
         auto startsWithNot = array.first().toString().startsWith("!");
@@ -156,7 +156,7 @@ QVariant Evaluator::compare(const QJsonArray &array, const AbstractLayerFeature 
                 break;
             }
         }else{
-            operand1 = feature->fetureMetaData.contains(temp) ? feature->fetureMetaData[temp] : QVariant();
+            operand1 = feature->featureMetaData.contains(temp) ? feature->featureMetaData[temp] : QVariant();
         }
     }else{
         QString temp = array.at(1).toString();
@@ -175,7 +175,7 @@ QVariant Evaluator::compare(const QJsonArray &array, const AbstractLayerFeature 
                 break;
             }
         }else{
-            operand1 = feature->fetureMetaData.contains(temp) ? feature->fetureMetaData[temp] : QVariant();
+            operand1 = feature->featureMetaData.contains(temp) ? feature->featureMetaData[temp] : QVariant();
         }
     }
 

--- a/lib/Layerstyle.h
+++ b/lib/Layerstyle.h
@@ -4,7 +4,7 @@
 #include <QtTypes>
 #include <QString>
 #include <QColor>
-#include <Qimage>
+#include <QImage>
 #include <QFont>
 #include <QJsonDocument>
 #include <QJsonObject>

--- a/lib/VectorTiles.cpp
+++ b/lib/VectorTiles.cpp
@@ -213,7 +213,6 @@ PointFeature* pointFeatureFromProto(const vector_tile::Tile::Feature &feature)
 */
 void populateFeatureMetaData(AbstractLayerFeature* feature, QList<QString> &keys, QList<vector_tile::Tile_QtProtobufNested::Value> &values)
 {
-
     if(!feature || feature->tags.length() < 2) return;
     for(int i = 0; i <= feature->tags.length() - 2; i += 2){
         int keyIndex = feature->tags.at(i);
@@ -221,19 +220,19 @@ void populateFeatureMetaData(AbstractLayerFeature* feature, QList<QString> &keys
         QString key = keys.at(keyIndex);
         auto value = values.at(valueIndex);
         if(value.hasStringValue()){
-            feature->fetureMetaData.insert(key, QVariant(value.stringValue()));
+            feature->featureMetaData.insert(key, QVariant(value.stringValue()));
         }else if(value.hasFloatValue()){
-            feature->fetureMetaData.insert(key, QVariant(value.floatValue()));
+            feature->featureMetaData.insert(key, QVariant(value.floatValue()));
         }else if(value.hasDoubleValue()){
-            feature->fetureMetaData.insert(key, QVariant(value.doubleValue()));
+            feature->featureMetaData.insert(key, QVariant(value.doubleValue()));
         }else if(value.hasIntValue()){
-            feature->fetureMetaData.insert(key, QVariant(value.intValue()));
+            feature->featureMetaData.insert(key, QVariant(static_cast<qint64>(value.intValue())));
         }else if(value.hasUintValue()){
-            feature->fetureMetaData.insert(key, QVariant(value.uintValue()));
+            feature->featureMetaData.insert(key, QVariant(static_cast<quint64>(value.intValue())));
         }else if(value.hasSintValue()){
-            feature->fetureMetaData.insert(key, QVariant(value.sintValue()));
+            feature->featureMetaData.insert(key, QVariant(static_cast<qint64>(value.sintValue())));
         }else if(value.hasBoolValue()){
-            feature->fetureMetaData.insert(key, QVariant(value.boolValue()));
+            feature->featureMetaData.insert(key, QVariant(value.boolValue()));
         }
     }
 }

--- a/lib/VectorTiles.h
+++ b/lib/VectorTiles.h
@@ -28,7 +28,7 @@ public:
 
     virtual featureType type() const = 0;
     QVector<unsigned int> tags;
-    QMap<QString, QVariant> fetureMetaData;
+    QMap<QString, QVariant> featureMetaData;
 private:
     int m_id;
 };

--- a/tests/unit-tests/unittest_evaluator.cpp
+++ b/tests/unit-tests/unittest_evaluator.cpp
@@ -13,8 +13,13 @@ class UnitTesting : public QObject
 
 private:
     const QString expressionTestPath = ":/unitTestResources/expressionTest.json";
-    QJsonObject expressionsObject;
-    QFile file;
+    QJsonObject mutableExpressionsObject;
+    const QJsonObject expressionsObject() const { return mutableExpressionsObject; }
+
+    void setExpressionsObject(QJsonObject obj)
+    {
+        mutableExpressionsObject = obj;
+    }
 
     // Checks if expected and gotten double floating point values are within 0.0001 of each other.
     bool validDoubleRange(double double1, double double2)
@@ -50,6 +55,8 @@ QTEST_MAIN(UnitTesting)
 
 void UnitTesting::initTestCase()
 {
+    QFile file;
+
     // Verify that the test file can be opened.
     file.setFileName(expressionTestPath);
     QJsonDocument doc;
@@ -62,8 +69,10 @@ void UnitTesting::initTestCase()
     if(parseError.error != QJsonParseError::NoError)
         QFAIL("Could not parse JSON file into a QJsonDocument: " + expressionTestPath.toUtf8());
 
-    expressionsObject = doc.object();
+    QJsonObject obj = doc.object();
+    setExpressionsObject(obj);
 
+    file.close();
 }
 
 // Test resolve expression function when the get value is passed in.
@@ -75,8 +84,8 @@ void UnitTesting::resolveExpression_with_get_value()
     QJsonArray expression;
     QVariant result;
 
-    QJsonObject expressionObject = expressionsObject.value("get").toObject();
-    feature.fetureMetaData.insert("class", "grass");
+    QJsonObject expressionObject = expressionsObject().value("get").toObject();
+    feature.featureMetaData.insert("class", "grass");
 
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
@@ -103,8 +112,8 @@ void UnitTesting::resolveExpression_with_has_value() {
     QJsonArray expression;
     QVariant result;
 
-    QJsonObject expressionObject = expressionsObject.value("has").toObject();
-    feature.fetureMetaData.insert("subclass", "farm");
+    QJsonObject expressionObject = expressionsObject().value("has").toObject();
+    feature.featureMetaData.insert("subclass", "farm");
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
     errorMessage = QString("\"has\" function returns empty result when a bool is expected");
@@ -135,8 +144,8 @@ void UnitTesting::resolveExpression_with_in_value()
     QJsonArray expression;
     QVariant result;
 
-    QJsonObject expressionObject = expressionsObject.value("in").toObject();
-    feature.fetureMetaData.insert("class", "residential");
+    QJsonObject expressionObject = expressionsObject().value("in").toObject();
+    feature.featureMetaData.insert("class", "residential");
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
     errorMessage = QString("\"in\" function returns empty result when a bool is expected");
@@ -168,8 +177,8 @@ void UnitTesting::resolveExpression_with_equals_value()
     QJsonArray expression;
     QVariant result;
 
-    QJsonObject expressionObject = expressionsObject.value("==").toObject();
-    feature.fetureMetaData.insert("class", "neighbourhood");
+    QJsonObject expressionObject = expressionsObject().value("==").toObject();
+    feature.featureMetaData.insert("class", "neighbourhood");
 
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
@@ -219,8 +228,8 @@ void UnitTesting::resolveExpression_with_inequality_value()
     QJsonArray expression;
     QVariant result;
 
-    QJsonObject expressionObject = expressionsObject.value("!=").toObject();
-    feature.fetureMetaData.insert("class", "neighbourhood");
+    QJsonObject expressionObject = expressionsObject().value("!=").toObject();
+    feature.featureMetaData.insert("class", "neighbourhood");
 
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
@@ -251,8 +260,8 @@ void UnitTesting::resolveExpression_with_greater_than_value()
     QJsonArray expression;
     QVariant result;
 
-    QJsonObject expressionObject = expressionsObject.value(">").toObject();
-    feature.fetureMetaData.insert("intermittent", 1);
+    QJsonObject expressionObject = expressionsObject().value(">").toObject();
+    feature.featureMetaData.insert("intermittent", 1);
 
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
@@ -283,10 +292,10 @@ void UnitTesting::resolveExpression_with_all_value()
     QJsonArray expression;
     QVariant result;
 
-    QJsonObject expressionObject = expressionsObject.value("all").toObject();
-    feature.fetureMetaData.insert("class", "neighbourhood");
-    feature.fetureMetaData.insert("intermittent", 1);
-    feature.fetureMetaData.insert("subclass", "farm");
+    QJsonObject expressionObject = expressionsObject().value("all").toObject();
+    feature.featureMetaData.insert("class", "neighbourhood");
+    feature.featureMetaData.insert("intermittent", 1);
+    feature.featureMetaData.insert("subclass", "farm");
 
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
@@ -317,8 +326,8 @@ void UnitTesting::resolveExpression_with_case_value()
     bool validDoubleError=false;
 
     //Parse the json file into a QJsonDocument for further processing.
-    QJsonObject expressionObject = expressionsObject.value("case").toObject();
-    feature.fetureMetaData.insert("class", "neighbourhood");
+    QJsonObject expressionObject = expressionsObject().value("case").toObject();
+    feature.featureMetaData.insert("class", "neighbourhood");
 
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
@@ -349,8 +358,8 @@ void UnitTesting::resolveExpression_with_coalesce_value()
     QJsonArray expression;
     QVariant result;
 
-    QJsonObject expressionObject = expressionsObject.value("coalesce").toObject();
-    feature.fetureMetaData.insert("class", "neighbourhood");
+    QJsonObject expressionObject = expressionsObject().value("coalesce").toObject();
+    feature.featureMetaData.insert("class", "neighbourhood");
 
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
@@ -377,10 +386,10 @@ void UnitTesting::resolveExpression_with_match_value()
     QVariant result;
 
     bool validDoubleError = false;
-    feature.fetureMetaData.clear();
-    feature.fetureMetaData.insert("class", "neighbourhood");
+    feature.featureMetaData.clear();
+    feature.featureMetaData.insert("class", "neighbourhood");
 
-    QJsonObject expressionObject = expressionsObject.value("match").toObject();
+    QJsonObject expressionObject = expressionsObject().value("match").toObject();
     expression = expressionObject.value("positive").toArray();
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
     errorMessage = QString("\"match\" function returns empty result when an int is expected");
@@ -414,8 +423,8 @@ void UnitTesting::resolveExpression_with_interpolate_value()
     bool validDoubleError=false; // Checks if double values are in a valid range
     double expectedInterpolationResult;
 
-    expression = expressionsObject.value("interpolate").toArray();
-    feature.fetureMetaData.insert("class", "neighbourhood");
+    expression = expressionsObject().value("interpolate").toArray();
+    feature.featureMetaData.insert("class", "neighbourhood");
 
 
     expectedInterpolationResult = 11;
@@ -492,10 +501,10 @@ void UnitTesting::resolveExpression_with_compound_value()
     bool validDoubleError=false;
     double expectedInterpolationResult;
 
-    QJsonObject expressionObject = expressionsObject.value("compound").toObject();
+    QJsonObject expressionObject = expressionsObject().value("compound").toObject();
     QJsonArray expression = expressionObject.value("expression1").toArray();
 
-    feature.fetureMetaData.insert("class", "motorway");
+    feature.featureMetaData.insert("class", "motorway");
 
     expectedInterpolationResult = 0.5;
     result = Evaluator::resolveExpression(expression, &feature, 0, 0);
@@ -513,7 +522,7 @@ void UnitTesting::resolveExpression_with_compound_value()
     validDoubleError = validDoubleRange(result.toDouble(), expectedInterpolationResult);
     QVERIFY2(validDoubleError, errorMessage.toUtf8());
 
-    feature.fetureMetaData.insert("brunnel", "bridge");
+    feature.featureMetaData.insert("brunnel", "bridge");
     expectedInterpolationResult =1 + (1*(-1.)/4);
     result = Evaluator::resolveExpression(expression, &feature, 7, 0);
     errorMessage = QString("Wrong result from \"interpolate\" function for zoom level 7, expected %1 but got %2")
@@ -530,7 +539,7 @@ void UnitTesting::resolveExpression_with_compound_value()
     validDoubleError = validDoubleRange(result.toDouble(), expectedInterpolationResult);
     QVERIFY2(validDoubleError, errorMessage.toUtf8());
 
-    feature.fetureMetaData.insert("ramp", 1);
+    feature.featureMetaData.insert("ramp", 1);
     expectedInterpolationResult =0.5;
     result = Evaluator::resolveExpression(expression, &feature, 11, 0);
     errorMessage = QString("Wrong result from \"interpolate\" function for zoom level 11, expected %1 but got %2")
@@ -539,8 +548,8 @@ void UnitTesting::resolveExpression_with_compound_value()
     validDoubleError = validDoubleRange(result.toDouble(), expectedInterpolationResult);
     QVERIFY2(validDoubleError, errorMessage.toUtf8());
 
-    feature.fetureMetaData.clear();
-    feature.fetureMetaData.insert("class", "service");
+    feature.featureMetaData.clear();
+    feature.featureMetaData.insert("class", "service");
     expectedInterpolationResult =0.75;
     result = Evaluator::resolveExpression(expression, &feature, 11, 0);
     errorMessage = QString("Wrong result from \"interpolate\" function for zoom level 11, expected %1 but got %2")
@@ -569,5 +578,5 @@ void UnitTesting::resolveExpression_with_compound_value()
 
 void UnitTesting::cleanupTestCase()
 {
-    file.close();
+    // Do nothing
 }


### PR DESCRIPTION
@cecilianor, here you have some suggestions after reading your post and checking your testing code (I have only checked the `Evaluator` tests).

1) There seems to be a small spelling mistake (feture -> feature). I have replace these.
2) I suggest a slightly different approach for the use of member variable across tests. In essence, I don't see any risks of using member variables across tests, provided that these variables are initialized properly (on init functions) and kept read-only. In this PR I propose wrapping the `expresssionsObject` variable in a function that returns the `const` form of it, so it is effectively constant.
3) I made the `QFile file` member variable local to the init function as it is not used anywhere else. 

You can apply 2)  and 3) across your tests.