### PR TITLE
fix (mouse panning): correct mouse cursor placement when panning in a…

### DIFF
--- a/app/MapWidget.cpp
+++ b/app/MapWidget.cpp
@@ -84,7 +84,7 @@ void MapWidget::mouseReleaseEvent(QMouseEvent *event)
  * \brief MapWidget::mouseMoveEvent records mouse position while a
  * mouse button is pressed.
  *
- * Note that a mouse button has to be pressed at the same time
+ * Note that the left mouse button has to be pressed at the same time
  * for this function to run.
  *
  * \param event is the event where the mouse is moved around.


### PR DESCRIPTION
The cursor should now stay on the map feature/placement where it was when the mouse button was pressed. Also handles a bug that would appear when the right instead of the left button was clicked while panning. Also removes redundant debug functionality that's no longer needed.

I'm merging it in to Nils' branch so that they can both be merged in to dev together in the same pull request.